### PR TITLE
Fix Hugo warning by adding empty redirects layout.

### DIFF
--- a/layouts/index.redirects
+++ b/layouts/index.redirects
@@ -1,0 +1,3 @@
+# Netlify redirects
+
+# No redirect rules currently needed.


### PR DESCRIPTION
When running `make run`, Hugo shows this warning:

```WARN  found no layout file for "redirects" for kind "home": You should create a template file which matches Hugo Layouts Lookup Rules for this combination.```

This PR silences the warning by adding an empty `layouts/index.redirects` file, where we can add home page redirects if needed in the future.

I think there's an alternative option to create a fallback layout for redirects at `layouts/_default/redirects` (instead of this PR's approach, which only addresses home page redirects). Let me know if you'd prefer that, or if there is something I'm missing - I'm new to Hugo and happy to learn.

Thanks!