### PR TITLE
Remove icon with broken link

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -180,11 +180,6 @@ params:
 
   # Footer Links
   links:
-    # End user relevant links. These will show up on left side of footer and in the community page if you have one.
-    user:
-      - name: Github Discussions
-        url: https://github.com/emissary-ingress/emissary/discussions
-        icon: fab fa-github
     # Developer relevant links. These will show up on right side of footer and in the community page if you have one.
     developer:
       - name: Emissary on GitHub


### PR DESCRIPTION
This PR removes an icon that linked to an empty page: https://github.com/emissary-ingress/emissary/discussions

Let me know if you prefer we link to something else with that icon.

Thanks!