### PR TITLE
Update Quick-Start with latest faces-demo

### DIFF
--- a/content/en/docs/3.10/quick-start.md
+++ b/content/en/docs/3.10/quick-start.md
@@ -89,7 +89,7 @@ check. First, install Faces itself using Helm:
 ```bash
 helm install faces \
  --namespace faces --create-namespace \
- oci://ghcr.io/buoyantio/faces-chart --version 2.0.0-rc.4 \
+ oci://ghcr.io/buoyantio/faces-chart --version 2.0.0 \
  --wait
 ```
 


### PR DESCRIPTION
https://github.com/BuoyantIO/faces-demo/releases

faces-demo is now available as a full release instead of only release candidate 🥳 . 

This changes the helm command documentation to target the release instead of rc.